### PR TITLE
bug fix: client connection could not receive the message sent by the server right after handshake response

### DIFF
--- a/t/server_initial_data.t
+++ b/t/server_initial_data.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use v5.10;
+use utf8;
+BEGIN { eval q{ use EV } }
+use AnyEvent;
+use AnyEvent::WebSocket::Client;
+use Test::More;
+use FindBin ();
+use lib $FindBin::Bin;
+use testlib::Server;
+
+testlib::Server->set_timeout;
+
+my $url = testlib::Server->start_server_with_initial_messages(
+  ["initial message from server"],
+  sub {
+    ## message callback
+    my ($frame, $message, $handle) = @_;
+    $handle->push_shutdown;
+  }
+);
+
+my $conn = AnyEvent::WebSocket::Client->new->connect($url)->recv;
+my $cv_finish = AnyEvent->condvar;
+my @received_messages = ();
+$conn->on(each_message => sub {
+  my ($conn, $message) = @_;
+  push(@received_messages, $message->body);
+  $conn->send("finish");
+  
+});
+$conn->on(finish => sub {
+  $cv_finish->send();
+});
+
+$cv_finish->recv;
+is_deeply(\@received_messages, ["initial message from server"],
+          "client connection should receive the initial message sent from server");
+
+done_testing;

--- a/t/testlib/Server.pm
+++ b/t/testlib/Server.pm
@@ -21,9 +21,9 @@ sub set_timeout
   });
 }
 
-sub start_server
+sub start_server_with_initial_messages
 {
-  my($class, $message_cb, $handshake_cb) = @_;
+  my($class, $messages_ref, $message_cb, $handshake_cb) = @_;
   my $server_cv = AnyEvent->condvar;
 
   tcp_server undef, undef, sub {
@@ -42,6 +42,10 @@ sub start_server
           if($handshake->is_done)
           {
             $hdl->push_write($handshake->to_string);
+            for my $message (@$messages_ref)
+            {
+              $hdl->push_write(Protocol::WebSocket::Frame->new($message)->to_bytes);
+            }
             $handshake_cb->($handshake)
               if $handshake_cb;
           }
@@ -67,6 +71,12 @@ sub start_server
   $uri->port($port);
   note "$uri";
   $uri;
+}
+
+sub start_server
+{
+  my($class, $message_cb, $handshake_cb) = @_;
+  return $class->start_server_with_initial_messages([], $message_cb, $handshake_cb);
 }
 
 sub start_echo


### PR DESCRIPTION
Because the on_read() callback was executed before registering any each_message/next_message callbacks,
the message sent by the server right after handshake response was discarded.

Now that it delays setting on_read() callback by AnyEvent->idle, each_message/next_message callbacks can receive the messages.
