### PR TITLE
Bug fix: prevent recursive call to "finish" callbacks

### DIFF
--- a/t/connection_finish_callback.t
+++ b/t/connection_finish_callback.t
@@ -47,4 +47,15 @@ test_case "close conn 0", sub {
   $conns->[0]->close();
 };
 
+test_case "recursively fire on_error event (in AE::Handle sense) while in on_eof handler", sub {
+  my $conns = shift;
+  $conns->[0]->on(finish => sub {
+    # It is very rude and unusual to use the handle directly. We don't
+    # have to support it, but it may happen.
+    $conns->[0]->handle->push_shutdown;
+    $conns->[0]->send("FOO"); # sending via a shutdown socket fires on_error ("Broken Pipe")
+  });
+  undef $conns->[1];
+};
+
 done_testing;


### PR DESCRIPTION
In some rare and stupid situations, "finish" callbacks can be called recursively (see the test). This patch fixes the bug by introducing _is_finished flag attribute.

Now that _is_finished flag ensures the finish callbacks are called only once, I removed the code that cleared _finish_cb. So the behavior is rolled back to versions <= 0.18
