### PR TITLE
Skip close code tests unless EV is available

### DIFF
--- a/t/mojo_close_codes.t
+++ b/t/mojo_close_codes.t
@@ -3,6 +3,7 @@ use warnings;
 use utf8;
 use AnyEvent::WebSocket::Client;
 use Test::More;
+BEGIN { plan skip_all => 'Requires EV' unless eval q{ use EV; 1 } }
 BEGIN { plan skip_all => 'Requires Mojolicious 3.0' unless eval q{ use Mojolicious 3.0; 1 } }
 BEGIN { plan skip_all => 'Requires Mojolicious::Lite' unless eval q{ use Mojolicious::Lite; 1 } }
 use FindBin;


### PR DESCRIPTION
For some reason, the close code tests I wrote based on the existing ones did not properly require EV, which meant the tests could fail.

This should fix that problem, pending a more permanent solution to #7