### PR TITLE
add a way to unregister callbacks

### DIFF
--- a/t/anyevent_websocket_client__ssl.t
+++ b/t/anyevent_websocket_client__ssl.t
@@ -55,7 +55,7 @@ $connection->send('ping');
 my $last;
 
 $connection->on(each_message => sub {
-  my $message = pop->body;
+  my $message = $_[1]->body;
   note "recv $message";
   $connection->send('ping');
   $last = $message;

--- a/t/mojo.t
+++ b/t/mojo.t
@@ -47,7 +47,7 @@ $connection->send('ping');
 my $last;
 
 $connection->on(each_message => sub {
-  my $message = pop->body;
+  my $message = $_[1]->body;
   note "recv $message";
   $connection->send('ping');
   $last = $message;


### PR DESCRIPTION
WARNING: this change might break the API. Before, there was some
bits of code that were doing

  $conn->on( each_message => sub { my $msg = pop } );

With this change, `pop` will gives the unregistering function, not the message...

Also, `on` was returning `$self`, but it was not documented or used. 