### PR TITLE
Add env_proxy attribute

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -45,6 +45,7 @@ URI::ws             = 0
 Protocol::WebSocket = 0.20
 Moo                 = 2.0
 AnyEvent            = 7.13
+AnyEvent::Connector = 0.02
 
 [Prereqs / SuggestedPrereqs]
 -relationship        = recommends

--- a/dist.ini
+++ b/dist.ini
@@ -45,7 +45,7 @@ URI::ws             = 0
 Protocol::WebSocket = 0.20
 Moo                 = 2.0
 AnyEvent            = 7.13
-AnyEvent::Connector = 0.02
+AnyEvent::Connector = 0.03
 
 [Prereqs / SuggestedPrereqs]
 -relationship        = recommends

--- a/lib/AnyEvent/WebSocket/Client.pm
+++ b/lib/AnyEvent/WebSocket/Client.pm
@@ -7,6 +7,7 @@ use AE;
 use AnyEvent;
 use AnyEvent::Handle;
 use AnyEvent::Socket ();
+use AnyEvent::Connector;
 use Protocol::WebSocket::Request;
 use Protocol::WebSocket::Handshake::Client;
 use AnyEvent::WebSocket::Connection;
@@ -195,6 +196,29 @@ has max_payload_size => (
   is => 'ro',
 );
 
+
+=head2 env_proxy
+
+If you set true to this boolean attribute, it loads proxy settings
+from environment variables. If it finds valid proxy settings,
+C<connect> method will use that proxy.
+
+Default: false.
+
+For C<ws> WebSocket end-points, first it reads C<ws_proxy> (or
+C<WS_PROXY>) environment variable. If it is not set or empty string,
+then it reads C<http_proxy> (or C<HTTP_PROXY>). For C<wss> WebSocket
+end-points, it reads C<wss_proxy> (C<WSS_PROXY>) and C<https_proxy>
+(C<HTTPS_PROXY>) environment variables.
+
+=cut
+
+has env_proxy => (
+  is => 'ro',
+  default => sub { 0 },
+);
+
+
 =head1 METHODS
 
 =head2 connect
@@ -232,7 +256,7 @@ sub connect
     return $done;
   }
     
-  AnyEvent::Socket::tcp_connect $uri->host, $uri->port, sub {
+  $self->make_tcp_connection($uri->scheme, $uri->host, $uri->port, sub {
     my $fh = shift;
     unless($fh)
     {
@@ -312,8 +336,33 @@ sub connect
         undef $done;
       }
     });
-  }, sub { $self->timeout };
+  }, sub { $self->timeout });
   $done;
+}
+
+sub make_tcp_connection
+{
+  my $self = shift;
+  my $scheme = shift;
+  my ($host, $port) = @_;
+  if(!$self->env_proxy)
+  {
+    return &AnyEvent::Socket::tcp_connect(@_);
+  }
+  my @connectors =
+      $scheme eq "ws"
+      ? (map { AnyEvent::Connector->new(env_proxy => $_) } qw(ws http))
+      : $scheme eq "wss"
+      ? (map { AnyEvent::Connector->new(env_proxy => $_) } qw(wss https))
+      : ();
+  foreach my $connector (@connectors)
+  {
+    if(defined($connector->proxy_for($host, $port)))
+    {
+      return $connector->tcp_connect(@_);
+    }
+  }
+  return &AnyEvent::Socket::tcp_connect(@_);
 }
 
 1;

--- a/lib/AnyEvent/WebSocket/Client.pm
+++ b/lib/AnyEvent/WebSocket/Client.pm
@@ -256,7 +256,7 @@ sub connect
     return $done;
   }
     
-  $self->make_tcp_connection($uri->scheme, $uri->host, $uri->port, sub {
+  $self->_make_tcp_connection($uri->scheme, $uri->host, $uri->port, sub {
     my $fh = shift;
     unless($fh)
     {
@@ -340,7 +340,7 @@ sub connect
   $done;
 }
 
-sub make_tcp_connection
+sub _make_tcp_connection
 {
   my $self = shift;
   my $scheme = shift;

--- a/xt/proxy.t
+++ b/xt/proxy.t
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+use Test::More;
+use AnyEvent;
+use AnyEvent::WebSocket::Client;
+use Try::Tiny;
+
+sub get_env {
+    my ($env_name, $desc) = @_;
+    my $val = $ENV{$env_name};
+    if(!defined($val) || $val eq "") {
+        plan skip_all => "Set $env_name environment variable to $desc to enable this test.";
+    }
+    return $val;
+}
+
+sub test_client_at {
+    my ($client, $echo_url, $exp_conn_success) = @_;
+    my ($conn, $err) = try {
+        (scalar($client->connect($echo_url)->recv), undef);
+    }catch {
+        (undef, $_[0])
+    };
+    if(!$exp_conn_success) {
+        is $conn, undef;
+        like $err, qr/unable to connect/i;
+        return;
+    }
+    isnt $conn, undef;
+    is $err, undef;
+    my $res_cv = AnyEvent->condvar;
+    $conn->on(next_message => sub {
+        $res_cv->send($_[1]->decoded_body);
+    });
+    $conn->send("foo bar");
+    my $got = $res_cv->recv;
+    is $got, "foo bar", $echo_url;
+}
+
+sub test_client {
+    my ($client, $exp_conn_success) = @_;
+    test_client_at($client, "ws://echo.websocket.org/", $exp_conn_success);
+    test_client_at($client, "wss://echo.websocket.org/", $exp_conn_success);
+}
+
+
+my $PROXY_URL = get_env("PERL_AE_WS_C_TEST_PROXY_URL", "the proxy URL");
+my $PROXY_ON =  get_env("PERL_AE_WS_C_TEST_PROXY_ON", "0 (if the proxy is down) or 1 (if the proxy is up)");
+
+foreach my $n (qw(ws http wss https)) {
+    my $e = "${n}_proxy";
+    delete $ENV{lc($e)};
+    delete $ENV{uc($e)};
+}
+
+subtest "no proxy", sub {
+    test_client(AnyEvent::WebSocket::Client->new(), 1);
+};
+
+subtest "ws and wss proxy", sub {
+    local $ENV{ws_proxy} = $PROXY_URL;
+    local $ENV{wss_proxy} = $PROXY_URL;
+    test_client(AnyEvent::WebSocket::Client->new(env_proxy => 1), $PROXY_ON);
+};
+
+subtest "http and https proxy", sub {
+    local $ENV{http_proxy} = $PROXY_URL;
+    local $ENV{https_proxy} = $PROXY_URL;
+    test_client(AnyEvent::WebSocket::Client->new(env_proxy => 1), $PROXY_ON);
+};
+
+done_testing;

--- a/xt/proxy.t
+++ b/xt/proxy.t
@@ -47,6 +47,15 @@ sub test_client {
 my $PROXY_URL = get_env("PERL_AE_WS_C_TEST_PROXY_URL", "the proxy URL");
 my $PROXY_ON =  get_env("PERL_AE_WS_C_TEST_PROXY_ON", "0 (if the proxy is down) or 1 (if the proxy is up)");
 
+diag(<<'NOTE');
+squid HTTP proxy denies connection to ports other than 443 (HTTPS) by default.
+In this case, this test fails. To pass the test, you have to configure squid.conf
+to allow connection to 80 (HTTP) and 443. For example,
+
+  ## http_access deny !Safe_ports
+  http_access allow CONNECT Safe_ports
+NOTE
+
 foreach my $n (qw(ws http wss https)) {
     my $e = "${n}_proxy";
     delete $ENV{lc($e)};


### PR DESCRIPTION
This p-r adds `env_proxy` attribute to Client. If set to true, it reads environment variables for proxy settings. If it successfully reads valid proxy settings, it uses that proxy to connect to WebSocket end-points.

To support proxy connection, it now depends on AnyEvent::Connector module.

The proxy connection is tested in `xt/proxy.t`, in which it actually connects to echo.websocket.org. The test is run only if certain environment variables are set, so travis skips this test.

This p-r closes #36, hopefully.

I'm not so familiar with Dist::Zilla, so you might need to revise dist.ini and other files.