### PR TITLE
cleanup ssl tests

### DIFF
--- a/t/anyevent_websocket_client__ssl.t
+++ b/t/anyevent_websocket_client__ssl.t
@@ -42,7 +42,6 @@ my $connection = eval { AnyEvent::WebSocket::Client->new( ssl_no_verify => 1 )->
 
 if(my $error = $@)
 {
-  #testlib::SSL->diag_about_issue22();
   die $error;
 }
 

--- a/t/lib/Test2/Require/SSL.pm
+++ b/t/lib/Test2/Require/SSL.pm
@@ -16,30 +16,4 @@ sub skip
   return;
 }
 
-sub diag_about_issue22
-{
-  my $ctx = context();
-  $ctx->diag("");
-  $ctx->diag("");
-  $ctx->diag(" == NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE ==");
-  $ctx->diag("");
-  $ctx->diag("  Recent versions of AnyEvent, in combination of Net::SSLeay");
-  $ctx->diag("  broke the SSL test for AnyEvent::WebSocket::Client.");
-  $ctx->diag("  Please see the GitHub issue tracker for up to date information:");
-  $ctx->diag("");
-  $ctx->diag("  https://github.com/plicease/AnyEvent-WebSocket-Client/issues/22");
-  $ctx->diag("");
-  $ctx->diag("  If SSL is not important for your use case, you may consider");
-  $ctx->diag("  installing AnyEvent::WebSocket::Client anyway.  It should work");
-  $ctx->diag("  fine over non-encrypted channels.  You can set the environment");
-  $ctx->diag("  variable ANYEVENT_WEBSOCKET_TEST_SKIP_SSL to skip the SSL tests.");
-  $ctx->diag("");
-  $ctx->diag("  Patches to fix this will be gladly accepted.");
-  $ctx->diag("");
-  $ctx->diag(" == NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE ==");
-  $ctx->diag("");
-  $ctx->diag("");
-  $ctx->release;
-}
-
 1;


### PR DESCRIPTION
remove some cruft from when there were various bugs that borked AE+TLS.  Also the anyevent_websocket_client__server_initial_data_shutdown.t can run on environments sans TLS, it just has to skip the TLS test.