### PR TITLE
override host and port with positional arguments

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - You may now overide the host and port when using the
+    AnyEvent::WebSocket::Client's connect method.
 
 0.50      2019-01-14 10:49:47 -0500
   - Fixed a testing bug that was reportd on Debian Buster.

--- a/README.md
+++ b/README.md
@@ -147,10 +147,18 @@ end-points, it reads `wss_proxy` (`WSS_PROXY`) and `https_proxy`
 ## connect
 
     my $cv = $client->connect($uri)
+    my $cv = $client->connect($uri, $host, $port);
 
 Open a connection to the web server and open a WebSocket to the resource
 defined by the given URL.  The URL may be either an instance of [URI::ws](https://metacpan.org/pod/URI::ws),
 [URI::wss](https://metacpan.org/pod/URI::wss), or a string that represents a legal WebSocket URL.
+
+You can  override the connection host and port by passing them in as the
+second and third argument.  These values (if provided) are passed directly
+into [AnyEvent::Socket](https://metacpan.org/pod/AnyEvent::Socket)'s `tcp_connect` function, so please note that
+function's idiosyncrasies in the [AnyEvent::Socket](https://metacpan.org/pod/AnyEvent::Socket) documentation.  In
+particular,  you can pass in `unix/` as the host and a filesystem path
+as the "port" to connect to a unix domain socket.
 
 This method will return an [AnyEvent](https://metacpan.org/pod/AnyEvent) condition variable which you can 
 attach a callback to.  The value sent through the condition variable will

--- a/lib/AnyEvent/WebSocket/Client.pm
+++ b/lib/AnyEvent/WebSocket/Client.pm
@@ -234,10 +234,18 @@ has env_proxy => (
 =head2 connect
 
  my $cv = $client->connect($uri)
+ my $cv = $client->connect($uri, $host, $port);
 
 Open a connection to the web server and open a WebSocket to the resource
 defined by the given URL.  The URL may be either an instance of L<URI::ws>,
 L<URI::wss>, or a string that represents a legal WebSocket URL.
+
+You can  override the connection host and port by passing them in as the
+second and third argument.  These values (if provided) are passed directly
+into L<AnyEvent::Socket>'s C<tcp_connect> function, so please note that
+function's idiosyncrasies in the L<AnyEvent::Socket> documentation.  In
+particular,  you can pass in C<unix/> as the host and a filesystem path
+as the "port" to connect to a unix domain socket.
 
 This method will return an L<AnyEvent> condition variable which you can 
 attach a callback to.  The value sent through the condition variable will
@@ -249,13 +257,13 @@ such errors using C<eval>.
 
 sub connect
 {
-  my($self, $uri) = @_;
+  my($self, $uri, $host, $port) = @_;
   unless(ref $uri)
   {
     require URI;
     $uri = URI->new($uri);
   }
-  
+
   my $done = AE::cv;
 
   # TODO: should we also accept http and https URLs?
@@ -265,8 +273,11 @@ sub connect
     $done->croak("URI is not a websocket");
     return $done;
   }
-    
-  $self->_make_tcp_connection($uri->scheme, $uri->host, $uri->port, sub {
+
+  $host = $uri->host unless defined $host;
+  $port = $uri->port unless defined $port;
+
+  $self->_make_tcp_connection($uri->scheme, $host, $port, sub {
     my $fh = shift;
     unless($fh)
     {

--- a/t/anyevent_websocket_client.t
+++ b/t/anyevent_websocket_client.t
@@ -94,6 +94,52 @@ subtest 'tests against count server' => sub {
   
     is $last, 9, 'last = 9';
   };
+
+  subtest 'override' => sub {
+
+
+    subtest 'host' => sub {
+
+      my $uri = $uri->clone;
+      my $host = $uri->host;
+      $uri->host('bogus.test');
+      my @args = ($uri, $host);
+      note "args=$_" for @args;
+
+      my $connection = eval { AnyEvent::WebSocket::Client->new->connect(@args)->recv };
+      is $@, '', 'connect okay';
+
+    };
+
+    subtest 'port' => sub {
+
+      my $uri = $uri->clone;
+      my $port = $uri->port;
+      $uri->port($port+1);
+      my @args = ($uri, undef, $port);
+      note "args=$_" for map { defined $_ ? $_ : 'undef' } @args;
+
+      my $connection = eval { AnyEvent::WebSocket::Client->new->connect(@args)->recv };
+      is $@, '', 'connect okay';
+
+    };
+
+    subtest 'port' => sub {
+
+      my $uri = $uri->clone;
+      my $host = $uri->host;
+      my $port = $uri->port;
+      $uri->host("bogus.test");
+      $uri->port($port+1);
+      my @args = ($uri, $host, $port);
+      note "args=$_" for @args;
+
+      my $connection = eval { AnyEvent::WebSocket::Client->new->connect(@args)->recv };
+      is $@, '', 'connect okay';
+
+    };
+
+  };
   
   subtest 'version' => sub {
   


### PR DESCRIPTION
This PR allows the caller to specify host/port name overrides that are different from the URI.  It uses positional arguments that are passed directly in as-is (if defined) to `tcp_connect`, which also allows the caller to specify a unix domain socket in the usual way that you do for `tcp_connect`.