### PR TITLE
allow fail on buster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
     - env: CIP_TAG=5.10.1      CIP_ENV='PERL_AE_WS_C_TEST_PROXY_URL=http://localhost:3128 PERL_AE_WS_C_TEST_PROXY_ON=1'
     - env: CIP_TAG=5.10.0      CIP_ENV='PERL_AE_WS_C_TEST_PROXY_URL=http://localhost:3128 PERL_AE_WS_C_TEST_PROXY_ON=1'
     - env: CIP_TAG=5.8         CIP_ENV='PERL_AE_WS_C_TEST_PROXY_URL=http://localhost:3128 PERL_AE_WS_C_TEST_PROXY_ON=1'
+  allow_failures:
+    - env: CIP_TAG=5.28-buster CIP_ENV='PERL_AE_WS_C_TEST_PROXY_URL=http://localhost:3128 PERL_AE_WS_C_TEST_PROXY_ON=1'  
 
 cache:
   directories:

--- a/t/anyevent_websocket_client__proxy.t
+++ b/t/anyevent_websocket_client__proxy.t
@@ -1,3 +1,5 @@
+use lib 't/lib';
+use Test2::Plugin::AnyEvent::Timeout;
 use Test2::V0 -no_srand => 1;
 use AnyEvent;
 use AnyEvent::WebSocket::Client;


### PR DESCRIPTION
Thanks to Debian OpenSSL Net::SSLeay issues it looks as though the TLS tests fail on buster.